### PR TITLE
 Fixed Publishing Production Image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,16 +62,8 @@ jobs:
         - run:
             name: "Build container image and test"
             command: |
-              export ALPINE_VER=$(cat alpine-version.txt)
-              export GLIBC_VER=$(cat alpine-glibc-version.txt)
-              DH_IMG="${DH_IMG_REPO}:dev-<< pipeline.parameters.app_name >>"
-              echo "building ${DH_IMG}"
-              docker build --rm --no-cache \
-                -t "${DH_IMG}" \
-                --build-arg ALPINE_VER --build-arg GLIBC_VER \
-                --progress plain  .
-              docker run -it --rm --entrypoint=ls "${DH_IMG}" -la /usr/glibc-compat
-              docker run -it --rm "${DH_IMG}" --version
+              chmod +x ./.circleci/docker-image.sh
+              ./.circleci/docker-image.sh "dev"
 
     fetch-code:
       executor: go-get-latest
@@ -96,25 +88,8 @@ jobs:
         - run:
             name: Push Docker image
             command: |
-              export ALPINE_VER=$(cat alpine-version.txt)
-              export GLIBC_VER=$(cat alpine-glibc-version.txt)
-              export DH_IMAGE="${DH_IMG_REPO}:<< pipeline.parameters.app_name >>"
-              echo "${DH_PASS}" | docker login -u "${DH_USER}" --password-stdin
-              echo ""
-              echo ""
-              echo "Building ${DH_IMAGE}"
-              docker build --rm --no-cache \
-                  -t "${DH_IMG_REPO}:${ALPINE_VER}-${GLIBC_VER}" \
-                  --build-arg ALPINE_VER --build-arg GLIBC_VER \
-                  .
-              echo ""
-              echo ""
-              echo "Pushing ${DH_IMAGE}"
-              docker push "${DH_IMAGE}"
-              echo ""
-              echo ""
-              echo "Cleanup ${DH_IMAGE}"
-              docker rmi "${DH_IMAGE}"
+              chmod +x ./.circleci/docker-image.sh
+              ./.circleci/docker-image.sh "prod" -push 1
 
 workflows:
   quality-control: # Run on all branches and PRs except main|auto-*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
               docker build --rm --no-cache \
                   -t "${DH_IMG_REPO}:${ALPINE_VER}-${GLIBC_VER}" \
                   --build-arg ALPINE_VER --build-arg GLIBC_VER \
-                  --target "release" .
+                  .
               echo ""
               echo ""
               echo "Pushing ${DH_IMAGE}"

--- a/.circleci/docker-image.sh
+++ b/.circleci/docker-image.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+set -e
+
+img_tag="${1}"
+do_push="${2}"
+dbg="${3}"
+
+if [ -z "${img_tag}" ]; then
+    echo "missing required first argument docker image tag"
+    exit 1
+fi
+
+export ALPINE_VER=$(cat alpine-version.txt)
+export GLIBC_VER=$(cat alpine-glibc-version.txt)
+DH_IMG="${DH_IMG_REPO}:${img_tag}"
+echo "building ${DH_IMG}"
+
+docker build --rm --no-cache \
+    -t "${DH_IMG}" \
+    --build-arg ALPINE_VER --build-arg GLIBC_VER \
+    .
+
+echo ""
+echo ""
+export AWS_VER_INFO="$(docker run -t --rm "${DH_IMG}" --version)"
+export AWS_VER="$(echo "${AWS_VER_INFO}" | sed -E "s|^aws-cli/([0-9.]+).*|\1|")"
+echo "AWS_VER=${AWS_VER}"
+docker tag "${DH_IMG}" "${DH_IMG_REPO}:${AWS_VER}"
+
+if [ "${do_push}" = "-push" ]; then
+    echo ""
+    echo ""
+    echo "${DH_PASS}" | docker login -u "${DH_USER}" --password-stdin
+    echo "Pushing ${DH_IMG}:${AWS_VER}"
+    docker push "${DH_IMG}:${AWS_VER}"
+fi
+
+echo ""
+echo ""
+docker run -it --rm --entrypoint=ls "${DH_IMG_REPO}:${AWS_VER}" -la /usr/glibc-compat
+docker run -it --rm "${DH_IMG_REPO}:${AWS_VER}" --version
+
+echo ""
+echo ""
+
+if [ -n "${dbg}" ]; then
+    docker images
+fi
+
+echo "Cleanup ${DH_IMG} ${DH_IMG}:${AWS_VER}"
+docker rmi "${DH_IMG}"
+docker rmi "${DH_IMG_REPO}:${AWS_VER}"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Testing is critical before taking your app to production.
 
 ## Status
 
-
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/kohirens/docker-alpine-awscli/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/kohirens/docker-alpine-awscli/tree/main)
 
 ## Features
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
     container:
-        image: "kohirens/alpine-awscli:${ALPINE_VER}-${GLIBC_VER}"
+        image: "kohirens/alpine-awscli:dev"
         build:
             args:
                 ALPINE_VER: "${ALPINE_VER}"


### PR DESCRIPTION
## Added

* CircleCI Badge - The CircleCI status badge is now linked in the main README.md.

## Fixed

* Publishing Production Image - Removed non-existing target from the Docker build command.

## Changed

* Production Image Tag - Tagged the production image with the AWS CLI version instead of the release version of this repository. Which will help consumers determine which AWS CLI version they are pulling.